### PR TITLE
Update reader_footer_panel.dart

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -71,7 +71,7 @@ jobs:
           cache: 'gradle'
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'beta'
+          channel: 'stable'
           cache: true
       - run: flutter --version
       - name: Get dependencies

--- a/lib/src/pages/reader/reader_page.dart
+++ b/lib/src/pages/reader/reader_page.dart
@@ -105,15 +105,15 @@ class ReaderPageState extends State<ReaderPage> with WidgetsBindingObserver {
       providers: [
         Provider<ReaderController>(create: (_) => reader),
       ],
-      child: Scaffold(
-          appBar: AppBar(
-            toolbarHeight: 0,
-            backgroundColor: Theme.of(context).colorScheme.background,
-            elevation: 0,
-          ),
-          body: RecordWithInfoCard(
-            bottomPadding: 0,
-            showTranslationSourceSentences: false,
+      child: RecordWithInfoCard(
+        bottomPadding: 0,
+        showTranslationSourceSentences: false,
+        body: Scaffold(
+            appBar: AppBar(
+              toolbarHeight: 0,
+              backgroundColor: Theme.of(context).colorScheme.background,
+              elevation: 0,
+            ),
             body: SafeArea(
               child: Container(
                 color: Theme.of(context).colorScheme.background,
@@ -128,8 +128,8 @@ class ReaderPageState extends State<ReaderPage> with WidgetsBindingObserver {
                   ],
                 ),
               ),
-            ),
-          )),
+            )),
+      ),
     );
   }
 }

--- a/lib/src/pages/reader/widgets/reader_footer_panel.dart
+++ b/lib/src/pages/reader/widgets/reader_footer_panel.dart
@@ -12,16 +12,23 @@ class ReaderFooterPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final reader = context.read<ReaderController>();
+    const double bottomMargin = 40;
 
     return Padding(
-      padding: const EdgeInsets.symmetric(
-          horizontal: doubleDefaultMargin, vertical: defaultMargin),
+      padding: const EdgeInsets.only(
+          top: doubleDefaultMargin,
+          bottom: bottomMargin,
+          left: defaultMargin,
+          right: defaultMargin),
       child: Observer(builder: (_) {
+        int partCount = reader.chaptersContent.length;
         return Text(
-          LocaleKeys.part_of.tr(namedArgs: {
-            "currentPart": (reader.currentChapter + 1).toString(),
-            "partCount": (reader.chaptersContent.length).toString()
-          }),
+          partCount > 0
+              ? LocaleKeys.part_of.tr(namedArgs: {
+                  "currentPart": (reader.currentChapter + 1).toString(),
+                  "partCount": (partCount).toString()
+                })
+              : "",
           style: Theme.of(context).readerFooterPanelTextStyle,
         );
       }),

--- a/lib/src/pages/reader/widgets/reader_footer_panel.dart
+++ b/lib/src/pages/reader/widgets/reader_footer_panel.dart
@@ -12,14 +12,10 @@ class ReaderFooterPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final reader = context.read<ReaderController>();
-    const double bottomMargin = 40;
 
     return Padding(
-      padding: const EdgeInsets.only(
-          top: doubleDefaultMargin,
-          bottom: bottomMargin,
-          left: defaultMargin,
-          right: defaultMargin),
+      padding: const EdgeInsets.symmetric(
+          horizontal: doubleDefaultMargin, vertical: defaultMargin),
       child: Observer(builder: (_) {
         int partCount = reader.chaptersContent.length;
         return Text(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -452,14 +452,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.16"
-  flutter_page_indicator:
-    dependency: "direct main"
-    description:
-      name: flutter_page_indicator
-      sha256: a5b2992228c2827b69faed3977681a3f5c313c7f13d72272decbb2923d1d7176
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.3"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -1309,5 +1301,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.18.0 <4.0.0"
   flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,7 +69,6 @@ dependencies:
   card_swiper: ^2.0.4
   auto_size_text: ^3.0.0
   flip_card: ^0.6.0
-  flutter_page_indicator: ^0.0.3
   smooth_page_indicator:
     git: https://github.com/Relorer/smooth_page_indicator.git
   text_to_speech: ^0.2.3


### PR DESCRIPTION
Пофикшено отображение номера главы внизу страницы в читалке.

- Из-за использования стандартного паддинга ReaderFooterPanel физически не влезал на страницу - увеличил нижний паддинг до 40. 

- Ещё отображение инфы о главе некрасиво смотрится, если идёт загрузка книги (там висит что-то типа "Part 1 of 0"), поэтому пока пока кол-во глав == 0, выводим пустую строку.


До изменений: 
![image](https://user-images.githubusercontent.com/52603467/219709082-d115a99b-3c6e-404c-a9c3-cb915563a62d.png)
После: 
![image](https://user-images.githubusercontent.com/52603467/219709168-f3b9c6de-1b3a-44eb-a84e-e9fc3342eb51.png)
